### PR TITLE
feat: Install AppMap tools

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,15 +53,8 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: EndBug/add-and-commit@v7
         with:
-          add: dist
+          add: build
           message: 'chore: Packaged distribution of action-utils'
-
-      - name: Tag @v1
-        uses: rickstaa/action-create-tag@v1
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        with:
-          tag: v1
-          force_push_tag: true
 
   appmap-analysis:
     if: always()

--- a/build/downloadFile.d.ts
+++ b/build/downloadFile.d.ts
@@ -1,0 +1,1 @@
+export default function downloadFile(url: URL, path: string): Promise<void>;

--- a/build/downloadFile.js
+++ b/build/downloadFile.js
@@ -1,0 +1,40 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const fs_1 = require("fs");
+const promises_1 = require("fs/promises");
+const node_fetch_1 = __importDefault(require("node-fetch"));
+function downloadFile(url, path) {
+    return __awaiter(this, void 0, void 0, function* () {
+        let readStream;
+        if (url.protocol === 'file:') {
+            readStream = (yield (0, promises_1.open)(url.pathname, 'r')).createReadStream();
+        }
+        else {
+            const res = yield (0, node_fetch_1.default)(url);
+            if (!res)
+                throw new Error(`Could not download ${url}`);
+            if (!res.body)
+                throw new Error(`Response body for ${url} is empty`);
+            if (res.status !== 200)
+                throw new Error(`Could not download ${url}: ${res.statusText}`);
+            readStream = res.body;
+        }
+        const writeStream = (0, fs_1.createWriteStream)(path);
+        yield new Promise((resolve, reject) => {
+            readStream.on('error', reject).pipe(writeStream).on('error', reject).on('finish', resolve);
+        });
+    });
+}
+exports.default = downloadFile;

--- a/build/executeCommand.d.ts
+++ b/build/executeCommand.d.ts
@@ -1,0 +1,19 @@
+/// <reference types="node" />
+import { ExecOptions } from 'child_process';
+export type Command = {
+    cmd: string | string[];
+    options?: ExecOptions;
+};
+export type ExecuteOptionFlags = {
+    printCommand?: boolean;
+    printStdout?: boolean;
+    printStderr?: boolean;
+    allowedCodes?: number[];
+};
+export declare class ExecuteOptions {
+    printCommand: boolean;
+    printStdout: boolean;
+    printStderr: boolean;
+    allowedCodes: number[];
+}
+export default function executeCommand(cmd: string | Command, options?: ExecuteOptionFlags): Promise<string>;

--- a/build/index.d.ts
+++ b/build/index.d.ts
@@ -1,0 +1,8 @@
+export { default as log } from './log';
+export * from './log';
+export { default as executeCommand } from './executeCommand';
+export * from './executeCommand';
+export { default as verbose } from './verbose';
+export * from './waitFor';
+export { default as installAppMapTools, InstallAppMapToolsOptions } from './installAppMapTools';
+export { default as downloadFile } from './downloadFile';

--- a/build/index.js
+++ b/build/index.js
@@ -17,7 +17,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.verbose = exports.executeCommand = exports.log = void 0;
+exports.downloadFile = exports.installAppMapTools = exports.verbose = exports.executeCommand = exports.log = void 0;
 var log_1 = require("./log");
 Object.defineProperty(exports, "log", { enumerable: true, get: function () { return __importDefault(log_1).default; } });
 __exportStar(require("./log"), exports);
@@ -27,3 +27,7 @@ __exportStar(require("./executeCommand"), exports);
 var verbose_1 = require("./verbose");
 Object.defineProperty(exports, "verbose", { enumerable: true, get: function () { return __importDefault(verbose_1).default; } });
 __exportStar(require("./waitFor"), exports);
+var installAppMapTools_1 = require("./installAppMapTools");
+Object.defineProperty(exports, "installAppMapTools", { enumerable: true, get: function () { return __importDefault(installAppMapTools_1).default; } });
+var downloadFile_1 = require("./downloadFile");
+Object.defineProperty(exports, "downloadFile", { enumerable: true, get: function () { return __importDefault(downloadFile_1).default; } });

--- a/build/installAppMapTools.d.ts
+++ b/build/installAppMapTools.d.ts
@@ -1,0 +1,6 @@
+export type InstallAppMapToolsOptions = {
+    toolsURL?: string;
+    force?: boolean;
+    githubToken?: string;
+};
+export default function installAppMapTools(toolsPath: string, options?: InstallAppMapToolsOptions): Promise<void>;

--- a/build/installAppMapTools.js
+++ b/build/installAppMapTools.js
@@ -1,0 +1,69 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const os_1 = __importStar(require("os"));
+const locateToolsRelease_1 = __importDefault(require("./locateToolsRelease"));
+const log_1 = __importStar(require("./log"));
+const path_1 = require("path");
+const executeCommand_1 = __importDefault(require("./executeCommand"));
+const promises_1 = require("fs/promises");
+const fs_1 = require("fs");
+const downloadFile_1 = __importDefault(require("./downloadFile"));
+function installAppMapTools(toolsPath, options = {}) {
+    return __awaiter(this, void 0, void 0, function* () {
+        if ((0, fs_1.existsSync)(toolsPath) && !options.force) {
+            (0, log_1.default)(log_1.LogLevel.Info, `AppMap tools are already installed at ${toolsPath}. Skipping this step...`);
+            return;
+        }
+        const platform = [os_1.default.platform() === 'darwin' ? 'macos' : os_1.default.platform(), os_1.default.arch()].join('-');
+        const toolsReleaseURL = options.toolsURL || (yield (0, locateToolsRelease_1.default)(platform, options.githubToken));
+        if (!toolsReleaseURL)
+            throw new Error('Could not find @appland/appmap release');
+        (0, log_1.default)(log_1.LogLevel.Info, `Installing AppMap tools from ${toolsReleaseURL}`);
+        const appmapTempPath = (0, path_1.join)((0, os_1.tmpdir)(), 'appmap');
+        yield (0, downloadFile_1.default)(new URL(toolsReleaseURL), appmapTempPath);
+        try {
+            yield (0, executeCommand_1.default)(`mv ${appmapTempPath} ${toolsPath}`);
+        }
+        catch (e) {
+            yield (0, executeCommand_1.default)(`sudo mv ${appmapTempPath} ${toolsPath}`);
+        }
+        yield (0, promises_1.chmod)(toolsPath, 0o755);
+        (0, log_1.default)(log_1.LogLevel.Info, `AppMap tools are installed at ${toolsPath}`);
+    });
+}
+exports.default = installAppMapTools;

--- a/build/installAppMapTools.js
+++ b/build/installAppMapTools.js
@@ -54,7 +54,8 @@ function installAppMapTools(toolsPath, options = {}) {
         if (!toolsReleaseURL)
             throw new Error('Could not find @appland/appmap release');
         (0, log_1.default)(log_1.LogLevel.Info, `Installing AppMap tools from ${toolsReleaseURL}`);
-        const appmapTempPath = (0, path_1.join)((0, os_1.tmpdir)(), 'appmap');
+        const tempDir = yield (0, promises_1.mkdtemp)((0, path_1.join)((0, os_1.tmpdir)(), 'appmap-tools-'));
+        const appmapTempPath = (0, path_1.join)(tempDir, 'appmap');
         yield (0, downloadFile_1.default)(new URL(toolsReleaseURL), appmapTempPath);
         try {
             yield (0, executeCommand_1.default)(`mv ${appmapTempPath} ${toolsPath}`);
@@ -63,6 +64,7 @@ function installAppMapTools(toolsPath, options = {}) {
             yield (0, executeCommand_1.default)(`sudo mv ${appmapTempPath} ${toolsPath}`);
         }
         yield (0, promises_1.chmod)(toolsPath, 0o755);
+        yield (0, promises_1.rm)(tempDir, { recursive: true });
         (0, log_1.default)(log_1.LogLevel.Info, `AppMap tools are installed at ${toolsPath}`);
     });
 }

--- a/build/locateToolsRelease.d.ts
+++ b/build/locateToolsRelease.d.ts
@@ -1,0 +1,1 @@
+export default function locateToolsRelease(platform: string, githubToken?: string, retryDelay?: number): Promise<string | undefined>;

--- a/build/locateToolsRelease.js
+++ b/build/locateToolsRelease.js
@@ -1,0 +1,86 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const node_fetch_1 = __importDefault(require("node-fetch"));
+const log_1 = __importStar(require("./log"));
+function locateToolsRelease(platform, githubToken, retryDelay = 3000) {
+    return __awaiter(this, void 0, void 0, function* () {
+        let result;
+        let page = 1;
+        while (!result) {
+            const url = `https://api.github.com/repos/applandinc/appmap-js/releases?page=${page}&per_page=100`;
+            (0, log_1.default)(log_1.LogLevel.Debug, `Enumerating appmap-js releases: ${url}`);
+            const headers = {
+                Accept: 'application/vnd.github+json',
+            };
+            if (githubToken)
+                headers['Authorization'] = `Bearer ${githubToken}`;
+            const response = yield (0, node_fetch_1.default)(url, {
+                headers,
+            });
+            if (response.status === 403) {
+                let message;
+                try {
+                    message = (yield response.json()).message;
+                }
+                catch (e) {
+                    (0, log_1.default)(log_1.LogLevel.Warn, e.toString());
+                    message = `GitHub API rate limit likely exceeded: ${e}`;
+                }
+                (0, log_1.default)(log_1.LogLevel.Info, [`Received status code 'Forbidden' listing appmap-js releases (`, message, ')'].join(''));
+                (0, log_1.default)(log_1.LogLevel.Debug, `Waiting for ${retryDelay / 1000.0} seconds.`);
+                (0, log_1.default)(log_1.LogLevel.Info, `You can avoid the rate limit by setting 'github-token: \${{ secrets.GITHUB_TOKEN }}'`);
+                yield new Promise(resolve => setTimeout(resolve, retryDelay));
+                continue;
+            }
+            else if (response.status > 400) {
+                throw new Error(`GitHub API returned ${response.status} ${response.statusText}`);
+            }
+            const releases = yield response.json();
+            if (releases.length === 0)
+                break;
+            page += 1;
+            const release = releases.find((release) => /^@appland\/appmap-v\d+\./.test(release.name));
+            if (release) {
+                (0, log_1.default)(log_1.LogLevel.Info, `Using @appland/appmap release ${release.name} for ${platform}`);
+                result = release.assets.find((asset) => asset.name === `appmap-${platform}`).browser_download_url;
+            }
+        }
+        return result;
+    });
+}
+exports.default = locateToolsRelease;

--- a/build/log.d.ts
+++ b/build/log.d.ts
@@ -1,0 +1,17 @@
+export declare enum LogLevel {
+    Debug = "debug",
+    Info = "info",
+    Warn = "warn"
+}
+export interface Logger {
+    debug(message: string): void;
+    info(message: string): void;
+    warn(message: string): void;
+}
+export declare class ActionLogger implements Logger {
+    debug(message: string): void;
+    info(message: string): void;
+    warn(message: string): void;
+}
+export declare function setLogger(logger: Logger): void;
+export default function log(level: LogLevel, message: string): void;

--- a/build/log.js
+++ b/build/log.js
@@ -30,7 +30,7 @@ var LogLevel;
     LogLevel["Debug"] = "debug";
     LogLevel["Info"] = "info";
     LogLevel["Warn"] = "warn";
-})(LogLevel = exports.LogLevel || (exports.LogLevel = {}));
+})(LogLevel || (exports.LogLevel = LogLevel = {}));
 class ActionLogger {
     debug(message) {
         core.debug(message);

--- a/build/log.js
+++ b/build/log.js
@@ -52,7 +52,8 @@ function log(level, message) {
     if (!Logger) {
         if (message.endsWith('\n'))
             message = message.slice(0, -1);
-        console[level](message);
+        const logFunction = console[level] || console.warn;
+        logFunction(message);
         return;
     }
     Logger[level](message);

--- a/build/verbose.d.ts
+++ b/build/verbose.d.ts
@@ -1,0 +1,1 @@
+export default function verbose(v?: string | boolean): boolean;

--- a/build/waitFor.d.ts
+++ b/build/waitFor.d.ts
@@ -1,0 +1,2 @@
+export declare function waitFor(message: string, test: () => boolean | Promise<boolean>, timeout?: number): Promise<void>;
+export declare function wait(ms: number): Promise<void>;

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,4 +3,5 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   testTimeout: parseInt(process.env.TEST_TIMEOUT, 10) || 5000,
+  maxWorkers: 1,
 };

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@actions/core": "^1.10.1",
-    "node-fetch": "^2"
+    "node-fetch": "^3.3.2"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appland/action-utils",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": "AppLand, Inc",
   "license": "MIT",
   "main": "build/index.js",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@appland/appmap-agent-js": "^14.2.0",
     "@types/jest": "^29.5.0",
     "@types/node": "^18.15.11",
-    "@types/node-fetch": "^2.6.3",
+    "@types/node-fetch": "^2.6.6",
     "jest": "^29.5.0",
     "prettier": "^2.8.7",
     "ts-jest": "^29.0.5",
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@actions/core": "^1.10.1",
-    "node-fetch": "^3.3.2"
+    "node-fetch": "^2.6.6"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "AppLand, Inc",
   "license": "MIT",
   "main": "build/index.js",
-  "types": "src/index.ts",
+  "types": "build/index.d.ts",
   "scripts": {
     "build": "tsc",
     "watch": "tsc --watch",

--- a/src/downloadFile.ts
+++ b/src/downloadFile.ts
@@ -1,0 +1,23 @@
+import {createWriteStream} from 'fs';
+import {open} from 'fs/promises';
+import fetch from 'node-fetch';
+
+export default async function downloadFile(url: URL, path: string) {
+  let readStream: NodeJS.ReadableStream;
+  if (url.protocol === 'file:') {
+    readStream = (await open(url.pathname, 'r')).createReadStream();
+  } else {
+    const res = await fetch(url);
+    if (!res) throw new Error(`Could not download ${url}`);
+    if (!res.body) throw new Error(`Response body for ${url} is empty`);
+    if (res.status !== 200) throw new Error(`Could not download ${url}: ${res.statusText}`);
+
+    readStream = res.body;
+  }
+
+  const writeStream = createWriteStream(path);
+
+  await new Promise((resolve, reject) => {
+    readStream.on('error', reject).pipe(writeStream).on('error', reject).on('finish', resolve);
+  });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,5 @@ export {default as executeCommand} from './executeCommand';
 export * from './executeCommand';
 export {default as verbose} from './verbose';
 export * from './waitFor';
+export {default as installAppMapTools, InstallAppMapToolsOptions} from './installAppMapTools';
+export {default as downloadFile} from './downloadFile';

--- a/src/installAppMapTools.ts
+++ b/src/installAppMapTools.ts
@@ -1,0 +1,44 @@
+import os, {tmpdir} from 'os';
+import locateToolsRelease from './locateToolsRelease';
+import log, {LogLevel} from './log';
+import {join} from 'path';
+import executeCommand from './executeCommand';
+import {chmod, mkdtemp, rm} from 'fs/promises';
+import {existsSync} from 'fs';
+import downloadFile from './downloadFile';
+
+export type InstallAppMapToolsOptions = {
+  toolsURL?: string;
+  force?: boolean;
+  githubToken?: string;
+};
+
+export default async function installAppMapTools(
+  toolsPath: string,
+  options: InstallAppMapToolsOptions = {}
+) {
+  if (existsSync(toolsPath) && !options.force) {
+    log(LogLevel.Info, `AppMap tools are already installed at ${toolsPath}. Skipping this step...`);
+    return;
+  }
+
+  const platform = [os.platform() === 'darwin' ? 'macos' : os.platform(), os.arch()].join('-');
+  const toolsReleaseURL =
+    options.toolsURL || (await locateToolsRelease(platform, options.githubToken));
+  if (!toolsReleaseURL) throw new Error('Could not find @appland/appmap release');
+
+  log(LogLevel.Info, `Installing AppMap tools from ${toolsReleaseURL}`);
+
+  const tempDir = await mkdtemp(join(tmpdir(), 'appmap-tools-'));
+  const appmapTempPath = join(tempDir, 'appmap');
+  await downloadFile(new URL(toolsReleaseURL), appmapTempPath);
+  try {
+    await executeCommand(`mv ${appmapTempPath} ${toolsPath}`);
+  } catch (e) {
+    await executeCommand(`sudo mv ${appmapTempPath} ${toolsPath}`);
+  }
+  await chmod(toolsPath, 0o755);
+  await rm(tempDir, {recursive: true});
+
+  log(LogLevel.Info, `AppMap tools are installed at ${toolsPath}`);
+}

--- a/src/locateToolsRelease.ts
+++ b/src/locateToolsRelease.ts
@@ -1,0 +1,59 @@
+import fetch from 'node-fetch';
+import log, {LogLevel} from './log';
+
+export default async function locateToolsRelease(
+  platform: string,
+  githubToken?: string,
+  retryDelay = 3000
+): Promise<string | undefined> {
+  let result: string | undefined;
+  let page = 1;
+  while (!result) {
+    const url = `https://api.github.com/repos/applandinc/appmap-js/releases?page=${page}&per_page=100`;
+    log(LogLevel.Debug, `Enumerating appmap-js releases: ${url}`);
+    const headers: Record<string, string> = {
+      Accept: 'application/vnd.github+json',
+    };
+    if (githubToken) headers['Authorization'] = `Bearer ${githubToken}`;
+    const response = await fetch(url, {
+      headers,
+    });
+    if (response.status === 403) {
+      let message: string;
+      try {
+        message = (await response.json()).message;
+      } catch (e) {
+        log(LogLevel.Warn, (e as Error).toString());
+        message = `GitHub API rate limit likely exceeded: ${e}`;
+      }
+      log(
+        LogLevel.Info,
+        [`Received status code 'Forbidden' listing appmap-js releases (`, message, ')'].join('')
+      );
+      log(LogLevel.Debug, `Waiting for ${retryDelay / 1000.0} seconds.`);
+      log(
+        LogLevel.Info,
+        `You can avoid the rate limit by setting 'github-token: \${{ secrets.GITHUB_TOKEN }}'`
+      );
+      await new Promise(resolve => setTimeout(resolve, retryDelay));
+      continue;
+    } else if (response.status > 400) {
+      throw new Error(`GitHub API returned ${response.status} ${response.statusText}`);
+    }
+
+    const releases = await response.json();
+    if (releases.length === 0) break;
+
+    page += 1;
+    const release = releases.find((release: any) => /^@appland\/appmap-v\d+\./.test(release.name));
+
+    if (release) {
+      log(LogLevel.Info, `Using @appland/appmap release ${release.name} for ${platform}`);
+      result = release.assets.find(
+        (asset: any) => asset.name === `appmap-${platform}`
+      ).browser_download_url;
+    }
+  }
+
+  return result;
+}

--- a/src/log.ts
+++ b/src/log.ts
@@ -35,7 +35,8 @@ export function setLogger(logger: Logger) {
 export default function log(level: LogLevel, message: string) {
   if (!Logger) {
     if (message.endsWith('\n')) message = message.slice(0, -1);
-    console[level](message);
+    const logFunction = console[level] || console.warn;
+    logFunction(message);
     return;
   }
 

--- a/test/downloadFile.spec.ts
+++ b/test/downloadFile.spec.ts
@@ -1,0 +1,31 @@
+import {readFileSync} from 'fs';
+import downloadFile from '../src/downloadFile';
+import verbose from '../src/verbose';
+import {mkdir, rm} from 'fs/promises';
+import {join} from 'path';
+
+if (process.env.VERBOSE) verbose(true);
+
+describe('downloadFile', () => {
+  let testOutputDir = join(__dirname, '..', 'tmp', 'test-output');
+
+  beforeEach(() => mkdir(testOutputDir, {recursive: true}));
+  afterEach(() => rm(testOutputDir, {recursive: true, force: true}));
+  afterEach(() => jest.restoreAllMocks());
+
+  it('downloads a file', async () => {
+    await downloadFile(new URL(`file:///${__filename}`), join(testOutputDir, 'downloadFile.spec.ts'));
+
+    expect(readFileSync(join(testOutputDir, 'downloadFile.spec.ts'), 'utf8')).toEqual(
+      readFileSync(__filename, 'utf-8')
+    );
+  });
+
+  it('downloads a URL', async () => {
+    await downloadFile(new URL('https://google.com'), join(testOutputDir, 'google.com'));
+
+    expect(readFileSync(join(testOutputDir, 'google.com'), 'utf8').toLowerCase()).toContain(
+      'google'
+    );
+  });
+});

--- a/test/installAppMapTools.spec.ts
+++ b/test/installAppMapTools.spec.ts
@@ -1,0 +1,71 @@
+import fs, {existsSync, readFileSync} from 'fs';
+import installAppMapTools from '../src/installAppMapTools';
+import * as locateToolsRelease from '../src/locateToolsRelease';
+import * as downloadFile from '../src/downloadFile';
+import verbose from '../src/verbose';
+import {mkdir, readFile, rm, writeFile} from 'fs/promises';
+import {join} from 'path';
+
+if (process.env.VERBOSE) verbose(true);
+
+describe('installAppMapTools', () => {
+  let testOutputDir = join(__dirname, '..', 'tmp', 'test-output');
+
+  beforeEach(() => mkdir(testOutputDir, {recursive: true}));
+  afterEach(() => rm(testOutputDir, {recursive: true, force: true}));
+  afterEach(() => jest.restoreAllMocks());
+
+  describe('when tools are not already installed', () => {
+    it('installs them', async () => {
+      const mockLocateToolsRelease = jest.spyOn(locateToolsRelease, 'default');
+      mockLocateToolsRelease.mockResolvedValueOnce('https://example.com/appmap-linux-x64');
+      const mockDownloadFile = jest.spyOn(downloadFile, 'default');
+      let appmapTempPath: string;
+      mockDownloadFile.mockImplementation(async (_url, path) => {
+        appmapTempPath = path;
+        await writeFile(appmapTempPath, 'not-real-appmap-binary');
+      });
+
+      await installAppMapTools(join(testOutputDir, 'appmap-tools'), {force: true});
+
+      expect(mockLocateToolsRelease).toHaveBeenCalledTimes(1);
+      expect(mockDownloadFile).toHaveBeenCalledTimes(1);
+
+      expect(existsSync(join(testOutputDir, 'appmap-tools'))).toBeTruthy();
+      expect(await readFile(join(testOutputDir, 'appmap-tools'), 'utf8')).toEqual(
+        'not-real-appmap-binary'
+      );
+    });
+  });
+
+  describe('when tools are already installed', () => {
+    beforeEach(() => {
+      jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+    });
+
+    it('does not install them again', async () => {
+      const mockLocateToolsRelease = jest.spyOn(locateToolsRelease, 'default');
+      const mockDownloadFile = jest.spyOn(downloadFile, 'default');
+
+      await installAppMapTools('/no/such/dir');
+      expect(mockLocateToolsRelease).not.toHaveBeenCalled();
+      expect(mockDownloadFile).not.toHaveBeenCalled();
+    });
+
+    describe('and force option is true', () => {
+      it('installs them again', async () => {
+        const mockLocateToolsRelease = jest.spyOn(locateToolsRelease, 'default');
+        mockLocateToolsRelease.mockResolvedValueOnce('https://example.com/appmap-linux-x64');
+        const mockDownloadFile = jest.spyOn(downloadFile, 'default');
+        mockDownloadFile.mockImplementation(async (_url, path) => {
+          await writeFile(path, 'not-real-appmap-binary');
+        });
+
+        await installAppMapTools(join(testOutputDir, 'appmap-tools'), {force: true});
+
+        expect(mockLocateToolsRelease).toHaveBeenCalledTimes(1);
+        expect(mockDownloadFile).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+});

--- a/test/locateToolsRelease.spec.ts
+++ b/test/locateToolsRelease.spec.ts
@@ -57,7 +57,7 @@ describe('locateToolsRelease', () => {
     fetcher.mockResolvedValueOnce({
       status: 403,
       json: async () => ({
-        message: 'Rate limit exceeded'
+        message: 'Rate limit exceeded',
       }),
     } as fetch.Response);
     fetcher.mockResolvedValueOnce({

--- a/test/locateToolsRelease.spec.ts
+++ b/test/locateToolsRelease.spec.ts
@@ -1,0 +1,108 @@
+import * as fetch from 'node-fetch';
+import verbose from '../src/verbose';
+
+import locateToolsRelease from '../src/locateToolsRelease';
+
+if (process.env.VERBOSE) verbose(true);
+
+describe('locateToolsRelease', () => {
+  const githubToken = 'my-token';
+  const preRelease = {
+    name: '@appland/appmap-prerelease-v0.0.1',
+    assets: [
+      {
+        name: 'appmap-linux-x64',
+        browser_download_url: 'https://example.com/appmap-prerelease-linux-x64',
+      },
+    ],
+  };
+  const newRelease = {
+    name: '@appland/appmap-v0.0.2',
+    assets: [
+      {name: 'appmap-macos', browser_download_url: 'https://example.com/appmap-macos'},
+      {name: 'appmap-linux-x64', browser_download_url: 'https://example.com/appmap-linux-x64'},
+    ],
+  };
+  const oldRelease = {
+    name: '@appland/appmap-v0.0.1',
+    assets: [
+      {name: 'appmap-macos', browser_download_url: 'https://example.com/appmap-old-macos'},
+      {name: 'appmap-linux-x64', browser_download_url: 'https://example.com/appmap-old-linux-x64'},
+    ],
+  };
+
+  afterEach(() => jest.restoreAllMocks());
+
+  it('selects the first occurring @appland/appmap release', async () => {
+    const releases = [preRelease, newRelease, oldRelease];
+
+    const fetcher = jest.spyOn(fetch, 'default').mockResolvedValue({
+      status: 200,
+      json: async () => releases,
+    } as fetch.Response);
+
+    const toolsRelease = await locateToolsRelease('linux-x64', githubToken);
+    expect(toolsRelease).toEqual('https://example.com/appmap-linux-x64');
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries on forbiden', async () => {
+    const releases = [newRelease];
+
+    const fetcher = jest.spyOn(fetch, 'default');
+    fetcher.mockResolvedValueOnce({
+      status: 403,
+      json: async () => {},
+    } as fetch.Response);
+    fetcher.mockResolvedValueOnce({
+      status: 403,
+      json: async () => ({
+        message: 'Rate limit exceeded'
+      }),
+    } as fetch.Response);
+    fetcher.mockResolvedValueOnce({
+      status: 200,
+      json: async () => releases,
+    } as fetch.Response);
+
+    const toolsRelease = await locateToolsRelease('linux-x64', githubToken, 1);
+    expect(toolsRelease).toEqual('https://example.com/appmap-linux-x64');
+    expect(fetcher).toHaveBeenCalledTimes(3);
+  });
+
+  it('will paginate', async () => {
+    const fetcher = jest.spyOn(fetch, 'default');
+    fetcher.mockResolvedValueOnce({
+      status: 200,
+      json: async () => [preRelease],
+    } as fetch.Response);
+    fetcher.mockResolvedValueOnce({
+      status: 200,
+      json: async () => [newRelease],
+    } as fetch.Response);
+
+    const toolsRelease = await locateToolsRelease('linux-x64', githubToken);
+    expect(toolsRelease).toEqual('https://example.com/appmap-linux-x64');
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it('searches all pages', async () => {
+    const fetcher = jest.spyOn(fetch, 'default');
+    fetcher.mockResolvedValueOnce({
+      status: 200,
+      json: async () => [preRelease],
+    } as fetch.Response);
+    fetcher.mockResolvedValueOnce({
+      status: 200,
+      json: async () => [preRelease],
+    } as fetch.Response);
+    fetcher.mockResolvedValueOnce({
+      status: 200,
+      json: async () => [],
+    } as fetch.Response);
+
+    const toolsRelease = await locateToolsRelease('linux-x64', githubToken);
+    expect(toolsRelease).toBeUndefined();
+    expect(fetcher).toHaveBeenCalledTimes(3);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "strict": true,
     "noImplicitAny": true,
     "esModuleInterop": true,
-    "declaration": true,
+    "declaration": true
   },
-  "exclude": ["node_modules", "**/*.spec.ts"]
+  "exclude": ["node_modules", "**/*.spec.ts", "build"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
     "rootDir": "./src",
     "strict": true,
     "noImplicitAny": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "declaration": true,
   },
   "exclude": ["node_modules", "**/*.spec.ts"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -747,13 +747,13 @@
     expect "^29.0.0"
     pretty-format "^29.0.0"
 
-"@types/node-fetch@^2.6.3":
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.3.tgz#175d977f5e24d93ad0f57602693c435c57ad7e80"
-  integrity sha512-ETTL1mOEdq/sxUtgtOhKjyB2Irra4cjxksvcMUR5Zr4n+PxVhsCD9WS46oPbHL3et9Zde7CNRr+WUNlcHvsX+w==
+"@types/node-fetch@^2.6.6":
+  version "2.6.6"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.6.tgz#b72f3f4bc0c0afee1c0bc9cff68e041d01e3e779"
+  integrity sha512-95X8guJYhfqiuVVhRFxVQcf4hW/2bCuoPwDasMf/531STFoNoWTT7YDnWdXHEZKqAGUigmpG31r2FE70LwnzJw==
   dependencies:
     "@types/node" "*"
-    form-data "^3.0.0"
+    form-data "^4.0.0"
 
 "@types/node@*", "@types/node@^18.15.11":
   version "18.15.11"
@@ -1206,11 +1206,6 @@ cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-data-uri-to-buffer@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz#d8feb2b2881e6a4f58c2e08acfd0e2834e26222e"
-  integrity sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==
-
 debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.3:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
@@ -1400,14 +1395,6 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
-fetch-blob@^3.1.2, fetch-blob@^3.1.4:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/fetch-blob/-/fetch-blob-3.2.0.tgz#f09b8d4bbd45adc6f0c20b7e787e793e309dcce9"
-  integrity sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==
-  dependencies:
-    node-domexception "^1.0.0"
-    web-streams-polyfill "^3.0.3"
-
 fill-range@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
@@ -1423,10 +1410,10 @@ find-up@^4.0.0, find-up@^4.1.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
-form-data@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
-  integrity sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
@@ -1436,13 +1423,6 @@ format-util@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/format-util/-/format-util-1.0.5.tgz#1ffb450c8a03e7bccffe40643180918cc297d271"
   integrity sha512-varLbTj0e0yVyRpqQhuWV+8hlePAgaoFRhNFj50BNjEIrw1/DphHSObtqwskVCPWNgzwPoQrZAbfa/SBiicNeg==
-
-formdata-polyfill@^4.0.10:
-  version "4.0.10"
-  resolved "https://registry.yarnpkg.com/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz#24807c31c9d402e002ab3d8c720144ceb8848423"
-  integrity sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==
-  dependencies:
-    fetch-blob "^3.1.2"
 
 fs-minipass@^2.0.0:
   version "2.1.0"
@@ -2362,19 +2342,12 @@ net-socket-messaging@^0.1.6:
   resolved "https://registry.yarnpkg.com/net-socket-messaging/-/net-socket-messaging-0.1.6.tgz#834c708557b57ab9f01f159a3fab20e1a0dd5158"
   integrity sha512-BgaXV5maKblBgFE45/uXghIyC/IzbxRjnBU6g5BYBTVIABbnzkN/G23lIj6vHunnamg9A6pI8v887u+WxkuJvg==
 
-node-domexception@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-1.0.0.tgz#6888db46a1f71c0b76b3f7555016b63fe64766e5"
-  integrity sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==
-
-node-fetch@^3.3.2:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.3.2.tgz#d1e889bacdf733b4ff3b2b243eb7a12866a0b78b"
-  integrity sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==
+node-fetch@^2.6.6:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
+  integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
   dependencies:
-    data-uri-to-buffer "^4.0.0"
-    fetch-blob "^3.1.4"
-    formdata-polyfill "^4.0.10"
+    whatwg-url "^5.0.0"
 
 node-gyp@^8.4.0:
   version "8.4.1"
@@ -2869,6 +2842,11 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
+
 treeify@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/treeify/-/treeify-1.1.0.tgz#4e31c6a463accd0943879f30667c4fdaff411bb8"
@@ -2923,9 +2901,9 @@ type-fest@^0.21.3:
   integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
 
 typescript@^5.0.2:
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.2.tgz#891e1a90c5189d8506af64b9ef929fca99ba1ee5"
-  integrity sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.2.tgz#5ebb5e5a5b75f085f22bc3f8460fba308310fa78"
+  integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==
 
 unique-filename@^1.1.1:
   version "1.1.1"
@@ -2992,10 +2970,18 @@ walker@^1.0.8:
   dependencies:
     makeerror "1.0.12"
 
-web-streams-polyfill@^3.0.3:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz#71c2718c52b45fd49dbeee88634b3a60ceab42a6"
-  integrity sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 which@^2.0.1, which@^2.0.2:
   version "2.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1206,6 +1206,11 @@ cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
+data-uri-to-buffer@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz#d8feb2b2881e6a4f58c2e08acfd0e2834e26222e"
+  integrity sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==
+
 debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.3:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
@@ -1395,6 +1400,14 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
+fetch-blob@^3.1.2, fetch-blob@^3.1.4:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/fetch-blob/-/fetch-blob-3.2.0.tgz#f09b8d4bbd45adc6f0c20b7e787e793e309dcce9"
+  integrity sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==
+  dependencies:
+    node-domexception "^1.0.0"
+    web-streams-polyfill "^3.0.3"
+
 fill-range@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
@@ -1423,6 +1436,13 @@ format-util@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/format-util/-/format-util-1.0.5.tgz#1ffb450c8a03e7bccffe40643180918cc297d271"
   integrity sha512-varLbTj0e0yVyRpqQhuWV+8hlePAgaoFRhNFj50BNjEIrw1/DphHSObtqwskVCPWNgzwPoQrZAbfa/SBiicNeg==
+
+formdata-polyfill@^4.0.10:
+  version "4.0.10"
+  resolved "https://registry.yarnpkg.com/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz#24807c31c9d402e002ab3d8c720144ceb8848423"
+  integrity sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==
+  dependencies:
+    fetch-blob "^3.1.2"
 
 fs-minipass@^2.0.0:
   version "2.1.0"
@@ -2342,12 +2362,19 @@ net-socket-messaging@^0.1.6:
   resolved "https://registry.yarnpkg.com/net-socket-messaging/-/net-socket-messaging-0.1.6.tgz#834c708557b57ab9f01f159a3fab20e1a0dd5158"
   integrity sha512-BgaXV5maKblBgFE45/uXghIyC/IzbxRjnBU6g5BYBTVIABbnzkN/G23lIj6vHunnamg9A6pI8v887u+WxkuJvg==
 
-node-fetch@^2:
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.9.tgz#7c7f744b5cc6eb5fd404e0c7a9fec630a55657e6"
-  integrity sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==
+node-domexception@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-1.0.0.tgz#6888db46a1f71c0b76b3f7555016b63fe64766e5"
+  integrity sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==
+
+node-fetch@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.3.2.tgz#d1e889bacdf733b4ff3b2b243eb7a12866a0b78b"
+  integrity sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==
   dependencies:
-    whatwg-url "^5.0.0"
+    data-uri-to-buffer "^4.0.0"
+    fetch-blob "^3.1.4"
+    formdata-polyfill "^4.0.10"
 
 node-gyp@^8.4.0:
   version "8.4.1"
@@ -2842,11 +2869,6 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
-tr46@~0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
-  integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
-
 treeify@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/treeify/-/treeify-1.1.0.tgz#4e31c6a463accd0943879f30667c4fdaff411bb8"
@@ -2970,18 +2992,10 @@ walker@^1.0.8:
   dependencies:
     makeerror "1.0.12"
 
-webidl-conversions@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
-  integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
-
-whatwg-url@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
-  integrity sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
-  dependencies:
-    tr46 "~0.0.3"
-    webidl-conversions "^3.0.0"
+web-streams-polyfill@^3.0.3:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz#71c2718c52b45fd49dbeee88634b3a60ceab42a6"
+  integrity sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==
 
 which@^2.0.1, which@^2.0.2:
   version "2.0.2"


### PR DESCRIPTION
Provide `installAppMapTools`, so that any GitHub Action that uses this library can install the tools for itself, rather than having to rely on the [install-action](https://github.com/getappmap/install-action) already being run.

New commands include:

<img width="307" alt="Screen Shot 2023-09-29 at 3 55 40 PM" src="https://github.com/getappmap/action-utils/assets/86395/c57a60a8-70fb-491f-989b-dbdd57f9e92c">

These are ported over from `install-action`, but they are better tested now.

Related: https://github.com/getappmap/install-action/pull/26
