### PR TITLE
feat: Summary report

### DIFF
--- a/build/ArtifactStore.d.ts
+++ b/build/ArtifactStore.d.ts
@@ -1,0 +1,6 @@
+export default interface ArtifactStore {
+    uploadArtifact(name: string, files: string[], retentionDays?: number): Promise<void>;
+}
+export declare function uploadArtifact(artifactStore: ArtifactStore, archiveFile: string, retentionDays?: number): Promise<{
+    archiveFile: string;
+}>;

--- a/build/ArtifactStore.js
+++ b/build/ArtifactStore.js
@@ -1,0 +1,51 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.uploadArtifact = void 0;
+const path_1 = require("path");
+const log_1 = __importStar(require("./log"));
+function uploadArtifact(artifactStore, archiveFile, retentionDays) {
+    return __awaiter(this, void 0, void 0, function* () {
+        (0, log_1.default)(log_1.LogLevel.Debug, `Processing AppMap archive ${archiveFile}`);
+        // e.g. .appmap/archive/full
+        const dir = (0, path_1.dirname)(archiveFile);
+        // e.g. appmap-archive-full
+        const artifactPrefix = dir.replace(/\//g, '-').replace(/\./g, '');
+        const [sha] = (0, path_1.basename)(archiveFile).split('.');
+        const artifactName = `${artifactPrefix}_${sha}.tar`;
+        yield artifactStore.uploadArtifact(artifactName, [archiveFile], retentionDays);
+        return { archiveFile };
+    });
+}
+exports.uploadArtifact = uploadArtifact;

--- a/build/Commenter.d.ts
+++ b/build/Commenter.d.ts
@@ -2,14 +2,21 @@ import { Octokit } from '@octokit/rest';
 export type Comment = {
     id: number;
 };
+export type Repo = {
+    owner: string;
+    repo: string;
+};
 export default class Commenter {
     private readonly octokit;
     readonly commentName: string;
-    readonly commentFile: string;
-    constructor(octokit: Octokit, commentName: string, commentFile: string);
+    readonly issueNumber: number;
+    readonly repo: Repo;
+    constructor(octokit: Octokit, commentName: string, issueNumber?: number, repo?: Repo);
+    commentExists(): Promise<boolean>;
+    comment(commentFile: string): Promise<void>;
+    getAppMapComment(): Promise<Comment | undefined>;
     static commentTagPattern(commentName: string): string;
+    static get repo(): Repo;
     static get issueNumber(): number | undefined;
     static get hasIssueNumber(): boolean;
-    comment(): Promise<void>;
-    getAppMapComment(issueNumber: number): Promise<Comment | undefined>;
 }

--- a/build/Commenter.d.ts
+++ b/build/Commenter.d.ts
@@ -16,7 +16,7 @@ export default class Commenter {
     comment(commentFile: string): Promise<void>;
     getAppMapComment(): Promise<Comment | undefined>;
     static commentTagPattern(commentName: string): string;
-    static get repo(): Repo;
-    static get issueNumber(): number | undefined;
-    static get hasIssueNumber(): boolean;
+    static repo(): Repo;
+    static issueNumber(): number | undefined;
+    static hasIssueNumber(): boolean;
 }

--- a/build/Commenter.js
+++ b/build/Commenter.js
@@ -49,10 +49,10 @@ class Commenter {
     constructor(octokit, commentName, issueNumber, repo) {
         this.octokit = octokit;
         this.commentName = commentName;
-        issueNumber || (issueNumber = Commenter.issueNumber);
+        issueNumber || (issueNumber = Commenter.issueNumber());
         (0, assert_1.default)(issueNumber);
         this.issueNumber = issueNumber;
-        this.repo = repo || Commenter.repo;
+        this.repo = repo || Commenter.repo();
     }
     commentExists() {
         return __awaiter(this, void 0, void 0, function* () {
@@ -100,17 +100,17 @@ class Commenter {
     static commentTagPattern(commentName) {
         return `<!-- "${commentName}" -->`;
     }
-    static get repo() {
+    static repo() {
         const { context } = github;
         return context.repo;
     }
-    static get issueNumber() {
+    static issueNumber() {
         var _a, _b;
         const { context } = github;
         return ((_a = context.payload.pull_request) === null || _a === void 0 ? void 0 : _a.number) || ((_b = context.payload.issue) === null || _b === void 0 ? void 0 : _b.number);
     }
-    static get hasIssueNumber() {
-        return !!Commenter.issueNumber;
+    static hasIssueNumber() {
+        return !!Commenter.issueNumber();
     }
 }
 exports.default = Commenter;

--- a/build/Commenter.js
+++ b/build/Commenter.js
@@ -46,46 +46,39 @@ const github = __importStar(require("@actions/github"));
 const assert_1 = __importDefault(require("assert"));
 const fs_1 = __importDefault(require("fs"));
 class Commenter {
-    constructor(octokit, commentName, commentFile) {
+    constructor(octokit, commentName, issueNumber, repo) {
         this.octokit = octokit;
         this.commentName = commentName;
-        this.commentFile = commentFile;
+        issueNumber || (issueNumber = Commenter.issueNumber);
+        (0, assert_1.default)(issueNumber);
+        this.issueNumber = issueNumber;
+        this.repo = repo || Commenter.repo;
     }
-    static commentTagPattern(commentName) {
-        return `<!-- "${commentName}" -->`;
-    }
-    static get issueNumber() {
-        var _a, _b;
-        const { context } = github;
-        return ((_a = context.payload.pull_request) === null || _a === void 0 ? void 0 : _a.number) || ((_b = context.payload.issue) === null || _b === void 0 ? void 0 : _b.number);
-    }
-    static get hasIssueNumber() {
-        return !!Commenter.issueNumber;
-    }
-    comment() {
+    commentExists() {
         return __awaiter(this, void 0, void 0, function* () {
-            (0, assert_1.default)(Commenter.hasIssueNumber);
-            const { context } = github;
-            const issueNumber = Commenter.issueNumber;
-            (0, assert_1.default)(issueNumber);
-            const content = fs_1.default.readFileSync(this.commentFile, 'utf8');
+            const comment = yield this.getAppMapComment();
+            return !!comment;
+        });
+    }
+    comment(commentFile) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const content = fs_1.default.readFileSync(commentFile, 'utf8');
             const body = `${content}\n${Commenter.commentTagPattern(this.commentName)}`;
-            const comment = yield this.getAppMapComment(issueNumber);
+            const comment = yield this.getAppMapComment();
             if (comment) {
-                yield this.octokit.rest.issues.updateComment(Object.assign(Object.assign({}, context.repo), { comment_id: comment.id, body }));
+                yield this.octokit.rest.issues.updateComment(Object.assign(Object.assign({}, this.repo), { comment_id: comment.id, body }));
             }
             else {
-                yield this.octokit.rest.issues.createComment(Object.assign(Object.assign({}, context.repo), { issue_number: issueNumber, body }));
+                yield this.octokit.rest.issues.createComment(Object.assign(Object.assign({}, this.repo), { issue_number: this.issueNumber, body }));
             }
         });
     }
-    getAppMapComment(issueNumber) {
+    getAppMapComment() {
         var _a, e_1, _b, _c;
         return __awaiter(this, void 0, void 0, function* () {
-            const { context } = github;
             let comment;
             try {
-                for (var _d = true, _e = __asyncValues(this.octokit.paginate.iterator(this.octokit.rest.issues.listComments, Object.assign(Object.assign({}, context.repo), { issue_number: issueNumber }))), _f; _f = yield _e.next(), _a = _f.done, !_a; _d = true) {
+                for (var _d = true, _e = __asyncValues(this.octokit.paginate.iterator(this.octokit.rest.issues.listComments, Object.assign(Object.assign({}, this.repo), { issue_number: this.issueNumber }))), _f; _f = yield _e.next(), _a = _f.done, !_a; _d = true) {
                     _c = _f.value;
                     _d = false;
                     const { data: comments } = _c;
@@ -103,6 +96,21 @@ class Commenter {
             }
             return comment;
         });
+    }
+    static commentTagPattern(commentName) {
+        return `<!-- "${commentName}" -->`;
+    }
+    static get repo() {
+        const { context } = github;
+        return context.repo;
+    }
+    static get issueNumber() {
+        var _a, _b;
+        const { context } = github;
+        return ((_a = context.payload.pull_request) === null || _a === void 0 ? void 0 : _a.number) || ((_b = context.payload.issue) === null || _b === void 0 ? void 0 : _b.number);
+    }
+    static get hasIssueNumber() {
+        return !!Commenter.issueNumber;
     }
 }
 exports.default = Commenter;

--- a/build/DirectoryArtifactStore.d.ts
+++ b/build/DirectoryArtifactStore.d.ts
@@ -1,0 +1,9 @@
+import ArtifactStore from './ArtifactStore';
+export default class DirectoryArtifactStore implements ArtifactStore {
+    directory: string;
+    constructor(directory: string);
+    /**
+     * @param _retentionDays Ignored by this implementation.
+     */
+    uploadArtifact(name: string, files: string[], _retentionDays: number): Promise<void>;
+}

--- a/build/DirectoryArtifactStore.js
+++ b/build/DirectoryArtifactStore.js
@@ -1,0 +1,57 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const promises_1 = require("fs/promises");
+const path_1 = require("path");
+const log_1 = __importStar(require("./log"));
+class DirectoryArtifactStore {
+    constructor(directory) {
+        this.directory = directory;
+    }
+    /**
+     * @param _retentionDays Ignored by this implementation.
+     */
+    uploadArtifact(name, files, _retentionDays) {
+        return __awaiter(this, void 0, void 0, function* () {
+            yield (0, promises_1.mkdir)(this.directory, { recursive: true });
+            (0, log_1.default)(log_1.LogLevel.Info, `Storing artifact ${name} in ${this.directory}`);
+            for (const file of files) {
+                (0, log_1.default)(log_1.LogLevel.Info, `\tFile ${file}`);
+                const target = (0, path_1.join)(this.directory, (0, path_1.basename)(file));
+                yield (0, promises_1.copyFile)(file, target);
+            }
+        });
+    }
+}
+exports.default = DirectoryArtifactStore;

--- a/build/GitHubArtifactStore.d.ts
+++ b/build/GitHubArtifactStore.d.ts
@@ -1,0 +1,4 @@
+import ArtifactStore from './ArtifactStore';
+export default class GitHubArtifactStore implements ArtifactStore {
+    uploadArtifact(name: string, files: string[], retentionDays?: number): Promise<void>;
+}

--- a/build/GitHubArtifactStore.js
+++ b/build/GitHubArtifactStore.js
@@ -1,0 +1,47 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const artifact = __importStar(require("@actions/artifact"));
+class GitHubArtifactStore {
+    uploadArtifact(name, files, retentionDays) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const artifactClient = artifact.create();
+            const options = {};
+            if (retentionDays)
+                options.retentionDays = retentionDays;
+            yield artifactClient.uploadArtifact(name, files, process.cwd(), options);
+        });
+    }
+}
+exports.default = GitHubArtifactStore;

--- a/build/index.d.ts
+++ b/build/index.d.ts
@@ -7,3 +7,6 @@ export * from './waitFor';
 export { default as installAppMapTools, InstallAppMapToolsOptions } from './installAppMapTools';
 export { default as downloadFile } from './downloadFile';
 export { default as Commenter, Comment } from './Commenter';
+export { default as ArtifactStore, uploadArtifact } from './ArtifactStore';
+export { default as GitHubArtifactStore } from './GitHubArtifactStore';
+export { default as DirectoryArtifactStore } from './DirectoryArtifactStore';

--- a/build/index.js
+++ b/build/index.js
@@ -17,7 +17,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.Commenter = exports.downloadFile = exports.installAppMapTools = exports.verbose = exports.executeCommand = exports.log = void 0;
+exports.DirectoryArtifactStore = exports.GitHubArtifactStore = exports.uploadArtifact = exports.Commenter = exports.downloadFile = exports.installAppMapTools = exports.verbose = exports.executeCommand = exports.log = void 0;
 var log_1 = require("./log");
 Object.defineProperty(exports, "log", { enumerable: true, get: function () { return __importDefault(log_1).default; } });
 __exportStar(require("./log"), exports);
@@ -33,3 +33,9 @@ var downloadFile_1 = require("./downloadFile");
 Object.defineProperty(exports, "downloadFile", { enumerable: true, get: function () { return __importDefault(downloadFile_1).default; } });
 var Commenter_1 = require("./Commenter");
 Object.defineProperty(exports, "Commenter", { enumerable: true, get: function () { return __importDefault(Commenter_1).default; } });
+var ArtifactStore_1 = require("./ArtifactStore");
+Object.defineProperty(exports, "uploadArtifact", { enumerable: true, get: function () { return ArtifactStore_1.uploadArtifact; } });
+var GitHubArtifactStore_1 = require("./GitHubArtifactStore");
+Object.defineProperty(exports, "GitHubArtifactStore", { enumerable: true, get: function () { return __importDefault(GitHubArtifactStore_1).default; } });
+var DirectoryArtifactStore_1 = require("./DirectoryArtifactStore");
+Object.defineProperty(exports, "DirectoryArtifactStore", { enumerable: true, get: function () { return __importDefault(DirectoryArtifactStore_1).default; } });

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "typescript": "^5.0.2"
   },
   "dependencies": {
+    "@actions/artifact": "^1.1.2",
     "@actions/core": "^1.10.1",
     "@actions/github": "^5.1.1",
     "@octokit/rest": "^20.0.2",

--- a/src/ArtifactStore.ts
+++ b/src/ArtifactStore.ts
@@ -1,0 +1,25 @@
+import {basename, dirname} from 'path';
+import log, {LogLevel} from './log';
+
+export default interface ArtifactStore {
+  uploadArtifact(name: string, files: string[], retentionDays?: number): Promise<void>;
+}
+
+export async function uploadArtifact(
+  artifactStore: ArtifactStore,
+  archiveFile: string,
+  retentionDays?: number
+): Promise<{archiveFile: string}> {
+  log(LogLevel.Debug, `Processing AppMap archive ${archiveFile}`);
+
+  // e.g. .appmap/archive/full
+  const dir = dirname(archiveFile);
+  // e.g. appmap-archive-full
+  const artifactPrefix = dir.replace(/\//g, '-').replace(/\./g, '');
+  const [sha] = basename(archiveFile).split('.');
+  const artifactName = `${artifactPrefix}_${sha}.tar`;
+
+  await artifactStore.uploadArtifact(artifactName, [archiveFile], retentionDays);
+
+  return {archiveFile};
+}

--- a/src/Commenter.ts
+++ b/src/Commenter.ts
@@ -9,56 +9,50 @@ export type Comment = {
   id: number;
 };
 
+export type Repo = {owner: string; repo: string};
+
 export default class Commenter {
+  public readonly issueNumber: number;
+  public readonly repo: Repo;
+
   constructor(
     private readonly octokit: Octokit,
     public readonly commentName: string,
-    public readonly commentFile: string
-  ) {}
-
-  static commentTagPattern(commentName: string): string {
-    return `<!-- "${commentName}" -->`;
-  }
-
-  static get issueNumber(): number | undefined {
-    const {context} = github;
-    return context.payload.pull_request?.number || context.payload.issue?.number;
-  }
-
-  static get hasIssueNumber(): boolean {
-    return !!Commenter.issueNumber;
-  }
-
-  public async comment() {
-    assert(Commenter.hasIssueNumber);
-
-    const {context} = github;
-
-    const issueNumber = Commenter.issueNumber;
+    issueNumber?: number,
+    repo?: Repo
+  ) {
+    issueNumber ||= Commenter.issueNumber;
     assert(issueNumber);
+    this.issueNumber = issueNumber;
+    this.repo = repo || Commenter.repo;
+  }
 
-    const content = fs.readFileSync(this.commentFile, 'utf8');
+  public async commentExists(): Promise<boolean> {
+    const comment = await this.getAppMapComment();
+    return !!comment;
+  }
+
+  public async comment(commentFile: string) {
+    const content = fs.readFileSync(commentFile, 'utf8');
     const body = `${content}\n${Commenter.commentTagPattern(this.commentName)}`;
-    const comment = await this.getAppMapComment(issueNumber);
+    const comment = await this.getAppMapComment();
 
     if (comment) {
       await this.octokit.rest.issues.updateComment({
-        ...context.repo,
+        ...this.repo,
         comment_id: comment.id,
         body,
       });
     } else {
       await this.octokit.rest.issues.createComment({
-        ...context.repo,
-        issue_number: issueNumber,
+        ...this.repo,
+        issue_number: this.issueNumber,
         body,
       });
     }
   }
 
-  public async getAppMapComment(issueNumber: number): Promise<Comment | undefined> {
-    const {context} = github;
-
+  public async getAppMapComment(): Promise<Comment | undefined> {
     type ListCommentsResponseDataType = GetResponseDataTypeFromEndpointMethod<
       typeof this.octokit.rest.issues.listComments
     >;
@@ -67,8 +61,8 @@ export default class Commenter {
     for await (const {data: comments} of this.octokit.paginate.iterator(
       this.octokit.rest.issues.listComments,
       {
-        ...context.repo,
-        issue_number: issueNumber,
+        ...this.repo,
+        issue_number: this.issueNumber,
       }
     )) {
       comment = comments.find(comment =>
@@ -78,5 +72,23 @@ export default class Commenter {
     }
 
     return comment;
+  }
+
+  static commentTagPattern(commentName: string): string {
+    return `<!-- "${commentName}" -->`;
+  }
+
+  static get repo(): Repo {
+    const {context} = github;
+    return context.repo;
+  }
+
+  static get issueNumber(): number | undefined {
+    const {context} = github;
+    return context.payload.pull_request?.number || context.payload.issue?.number;
+  }
+
+  static get hasIssueNumber(): boolean {
+    return !!Commenter.issueNumber;
   }
 }

--- a/src/Commenter.ts
+++ b/src/Commenter.ts
@@ -21,10 +21,10 @@ export default class Commenter {
     issueNumber?: number,
     repo?: Repo
   ) {
-    issueNumber ||= Commenter.issueNumber;
+    issueNumber ||= Commenter.issueNumber();
     assert(issueNumber);
     this.issueNumber = issueNumber;
-    this.repo = repo || Commenter.repo;
+    this.repo = repo || Commenter.repo();
   }
 
   public async commentExists(): Promise<boolean> {
@@ -78,17 +78,17 @@ export default class Commenter {
     return `<!-- "${commentName}" -->`;
   }
 
-  static get repo(): Repo {
+  static repo(): Repo {
     const {context} = github;
     return context.repo;
   }
 
-  static get issueNumber(): number | undefined {
+  static issueNumber(): number | undefined {
     const {context} = github;
     return context.payload.pull_request?.number || context.payload.issue?.number;
   }
 
-  static get hasIssueNumber(): boolean {
-    return !!Commenter.issueNumber;
+  static hasIssueNumber(): boolean {
+    return !!Commenter.issueNumber();
   }
 }

--- a/src/DirectoryArtifactStore.ts
+++ b/src/DirectoryArtifactStore.ts
@@ -1,0 +1,23 @@
+import {copyFile, mkdir} from 'fs/promises';
+import {basename, join} from 'path';
+
+import ArtifactStore from './ArtifactStore';
+import log, {LogLevel} from './log';
+
+export default class DirectoryArtifactStore implements ArtifactStore {
+  constructor(public directory: string) {}
+
+  /**
+   * @param _retentionDays Ignored by this implementation.
+   */
+  async uploadArtifact(name: string, files: string[], _retentionDays: number): Promise<void> {
+    await mkdir(this.directory, {recursive: true});
+
+    log(LogLevel.Info, `Storing artifact ${name} in ${this.directory}`);
+    for (const file of files) {
+      log(LogLevel.Info, `\tFile ${file}`);
+      const target = join(this.directory, basename(file));
+      await copyFile(file, target);
+    }
+  }
+}

--- a/src/GitHubArtifactStore.ts
+++ b/src/GitHubArtifactStore.ts
@@ -1,0 +1,11 @@
+import * as artifact from '@actions/artifact';
+import ArtifactStore from './ArtifactStore';
+
+export default class GitHubArtifactStore implements ArtifactStore {
+  async uploadArtifact(name: string, files: string[], retentionDays?: number): Promise<void> {
+    const artifactClient = artifact.create();
+    const options: artifact.UploadOptions = {};
+    if (retentionDays) options.retentionDays = retentionDays;
+    await artifactClient.uploadArtifact(name, files, process.cwd(), options);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,3 +7,6 @@ export * from './waitFor';
 export {default as installAppMapTools, InstallAppMapToolsOptions} from './installAppMapTools';
 export {default as downloadFile} from './downloadFile';
 export {default as Commenter, Comment} from './Commenter';
+export {default as ArtifactStore, uploadArtifact} from './ArtifactStore';
+export {default as GitHubArtifactStore} from './GitHubArtifactStore';
+export {default as DirectoryArtifactStore} from './DirectoryArtifactStore';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,17 @@
 # yarn lockfile v1
 
 
-"@actions/core@^1.10.1":
+"@actions/artifact@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@actions/artifact/-/artifact-1.1.2.tgz#13e796ce35214bd6486508f97b29b4b8e44f5a35"
+  integrity sha512-1gLONA4xw3/Q/9vGxKwkFdV9u1LE2RWGx/IpAqg28ZjprCnJFjwn4pA7LtShqg5mg5WhMek2fjpyH1leCmOlQQ==
+  dependencies:
+    "@actions/core" "^1.9.1"
+    "@actions/http-client" "^2.0.1"
+    tmp "^0.2.1"
+    tmp-promise "^3.0.2"
+
+"@actions/core@^1.10.1", "@actions/core@^1.9.1":
   version "1.10.1"
   resolved "https://registry.npmjs.org/@actions/core/-/core-1.10.1.tgz"
   integrity sha512-3lBR9EDAY+iYIpTnTIXmWcNbX3T2kCkAEQGIQx4NVQ0575nk2k3GRZDTPQG+vVtS2izSLmINlxXf0uLtnrTP+g==
@@ -2903,7 +2913,7 @@ retry@^0.12.0:
   resolved "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz"
   integrity sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==
 
-rimraf@^3.0.2:
+rimraf@^3.0.0, rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
@@ -3122,6 +3132,20 @@ test-exclude@^6.0.0:
     "@istanbuljs/schema" "^0.1.2"
     glob "^7.1.4"
     minimatch "^3.0.4"
+
+tmp-promise@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/tmp-promise/-/tmp-promise-3.0.3.tgz#60a1a1cc98c988674fcbfd23b6e3367bdeac4ce7"
+  integrity sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==
+  dependencies:
+    tmp "^0.2.0"
+
+tmp@^0.2.0, tmp@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.1.tgz#8457fc3037dcf4719c251367a1af6500ee1ccf14"
+  integrity sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==
+  dependencies:
+    rimraf "^3.0.0"
 
 tmpl@1.0.5:
   version "1.0.5"


### PR DESCRIPTION
Refactor Commenter and ArtifactStore to support publication of the summary report from `analyze-action`.

**Note** After merging this, update `package.json` in https://github.com/getappmap/archive-action/pull/38 and https://github.com/getappmap/analyze-action/pull/45 to use the `main` branch of this repository.